### PR TITLE
Temporal kills

### DIFF
--- a/src/Effect/Aff.js
+++ b/src/Effect/Aff.js
@@ -56,6 +56,12 @@ var Aff = function () {
   var FIBER     = "Fiber";     // Actual fiber reference
   var THUNK     = "Thunk";     // Primed effect, ready to invoke
 
+  // Error used for early cancelation on Alt branches.
+  // This is initialized here (rather than in the Fiber constructor) because
+  // otherwise, in V8, this Error object indefinitely hangs on to memory that
+  // otherwise would be garbage collected.
+  var early = new Error("[ParAff] Early exit");
+
   function Aff(tag, _1, _2, _3) {
     this.tag = tag;
     this._1  = _1;
@@ -659,9 +665,6 @@ var Aff = function () {
     // Table of currently running cancelers, as a product of `Alt` behavior.
     var killId    = 0;
     var kills     = {};
-
-    // Error used for early cancelation on Alt branches.
-    var early     = new Error("[ParAff] Early exit");
 
     // Error used to kill the entire tree.
     var interrupt = null;

--- a/src/Effect/Aff.js
+++ b/src/Effect/Aff.js
@@ -320,6 +320,7 @@ var Aff = function () {
 
           case ASYNC:
             status = PENDING;
+            step = nonCanceler;
             Scheduler.enqueue(function () {
               if (runTick !== localRunTick) {
                 return;

--- a/src/Effect/Aff.js
+++ b/src/Effect/Aff.js
@@ -332,29 +332,29 @@ var Aff = function () {
               if (runTick !== localRunTick) {
                 return;
               }
-              var issync = true;
-              var resolved = false;
+              var skipRun = true;
               var canceler = runAsync(util.left, tmp, function (result) {
                 return function () {
                   if (runTick !== localRunTick) {
                     return;
                   }
                   ++runTick;
-                  resolved = true;
                   status = STEP_RESULT;
                   step = result;
                   // Do not recurse on run if we are synchronous with runAsync. 
-                  if (!issync) {
+                  if (skipRun) {
+                    skipRun = false;
+                  } else {
                     run(runTick);
                   }
                 };
               });
-              issync = false;
               // Only update the canceler if the asynchronous action has not
               // resolved synchronously. If it has, then the next status and
               // step have already been set.
-              if (!resolved) {
+              if (skipRun) {
                 step = canceler;
+                skipRun = false;
               }
               // If runAsync already resolved then the next step needs to be
               // run.

--- a/src/Effect/Aff.js
+++ b/src/Effect/Aff.js
@@ -326,6 +326,7 @@ var Aff = function () {
               if (runTick !== localRunTick) {
                 return;
               }
+              var issync = true;
               var resolved = false;
               var canceler = runAsync(util.left, tmp, function (result) {
                 return function () {
@@ -336,16 +337,23 @@ var Aff = function () {
                   resolved = true;
                   status = STEP_RESULT;
                   step = result;
-                  // Free us from this callstack. Otherwise a memory leak may
-                  // happen on V8; not sure why.
-                  setTimeout(function () { run(runTick); }, 0);
+                  // Do not recurse on run if we are synchronous with runAsync. 
+                  if (!issync) {
+                    run(runTick);
+                  }
                 };
               });
+              issync = false;
               // Only update the canceler if the asynchronous action has not
               // resolved synchronously. If it has, then the next status and
               // step have already been set.
               if (!resolved) {
                 step = canceler;
+              }
+              // If runAsync already resolved then the next step needs to be
+              // run.
+              else {
+                run(runTick);
               }
             });
             return;

--- a/src/Effect/Aff.js
+++ b/src/Effect/Aff.js
@@ -590,6 +590,7 @@ var Aff = function () {
           break;
         case WAITING:
           Scheduler.enqueue(function () { kill(error, cb)(); });
+          break;
         default:
           if (interrupt === null) {
             interrupt = util.left(error);

--- a/src/Effect/Aff.purs
+++ b/src/Effect/Aff.purs
@@ -51,8 +51,8 @@ import Data.Time.Duration (Milliseconds(..))
 import Data.Time.Duration (Milliseconds(..)) as Exports
 import Effect (Effect)
 import Effect.Class (class MonadEffect, liftEffect)
-import Effect.Exception (Error, error)
-import Effect.Exception (Error, error, message) as Exports
+import Effect.Exception (Error)
+import Effect.Exception (Error, message) as Exports
 import Effect.Unsafe (unsafePerformEffect)
 import Partial.Unsafe (unsafeCrashWith)
 import Unsafe.Coerce (unsafeCoerce)
@@ -86,8 +86,11 @@ instance monoidAff ∷ Monoid a ⇒ Monoid (Aff a) where
 instance altAff ∷ Alt Aff where
   alt a1 a2 = catchError a1 (const a2)
 
+alwaysFailsError ∷ Error
+alwaysFailsError = stacklessError "Always fails"
+
 instance plusAff ∷ Plus Aff where
-  empty = throwError (error "Always fails")
+  empty = throwError alwaysFailsError
 
 -- | This instance is provided for compatibility. `Aff` is always stack-safe
 -- | within a given fiber. This instance will just result in unnecessary
@@ -306,6 +309,9 @@ type Supervised a =
   , supervisor ∷ Supervisor
   }
 
+parentOutlivedError ∷ Error
+parentOutlivedError = stacklessError "[Aff] Child fiber outlived parent"
+
 -- | Creates a new supervision context for some `Aff`, guaranteeing fiber
 -- | cleanup when the parent completes. Any pending fibers forked within
 -- | the context will be killed and have their cancelers run.
@@ -313,14 +319,11 @@ supervise ∷ ∀ a. Aff a → Aff a
 supervise aff =
   generalBracket (liftEffect acquire)
     { killed: \err sup → parSequence_ [ killFiber err sup.fiber, killAll err sup ]
-    , failed: const (killAll killError)
-    , completed: const (killAll killError)
+    , failed: const (killAll parentOutlivedError)
+    , completed: const (killAll parentOutlivedError)
     }
     (joinFiber <<< _.fiber)
   where
-  killError ∷ Error
-  killError =
-    error "[Aff] Child fiber outlived parent"
 
   killAll ∷ Error → Supervised a → Aff Unit
   killAll err sup = makeAff \k →

--- a/src/Effect/Aff.purs
+++ b/src/Effect/Aff.purs
@@ -51,8 +51,8 @@ import Data.Time.Duration (Milliseconds(..))
 import Data.Time.Duration (Milliseconds(..)) as Exports
 import Effect (Effect)
 import Effect.Class (class MonadEffect, liftEffect)
-import Effect.Exception (Error)
-import Effect.Exception (Error, message) as Exports
+import Effect.Exception (Error, error)
+import Effect.Exception (Error, error, message) as Exports
 import Effect.Unsafe (unsafePerformEffect)
 import Partial.Unsafe (unsafeCrashWith)
 import Unsafe.Coerce (unsafeCoerce)
@@ -87,7 +87,7 @@ instance altAff ∷ Alt Aff where
   alt a1 a2 = catchError a1 (const a2)
 
 alwaysFailsError ∷ Error
-alwaysFailsError = stacklessError "Always fails"
+alwaysFailsError = error "Always fails"
 
 instance plusAff ∷ Plus Aff where
   empty = throwError alwaysFailsError
@@ -310,7 +310,7 @@ type Supervised a =
   }
 
 parentOutlivedError ∷ Error
-parentOutlivedError = stacklessError "[Aff] Child fiber outlived parent"
+parentOutlivedError = error "[Aff] Child fiber outlived parent"
 
 -- | Creates a new supervision context for some `Aff`, guaranteeing fiber
 -- | cleanup when the parent completes. Any pending fibers forked within


### PR DESCRIPTION
Resolves #168

Instead of starting the asynchronous effect and scheduling processing of the result, the starting of the asynchronous effect is scheduled and the result is processed immediately.

Before, a Fiber could be PENDING even though the result was received, because it is waiting on the scheduler. Now, if a Fiber is PENDING it is guaranteed the result is not yet received.

Before, when a Fiber was killed in PENDING status it was possible that the result was already received. This meant that a kill which happened after the effect would retroactively kill it — a temporal inconsistency. Now, when a Fiber is killed in PENDING status it is necessarily the case that the kill occurred before the result was received.