### PR TITLE
Try to recover from effectful code that is annotated as pure

### DIFF
--- a/src/Effect/Aff.js
+++ b/src/Effect/Aff.js
@@ -274,12 +274,18 @@ var Aff = function () {
         switch (status) {
         case STEP_BIND:
           status = CONTINUE;
-          step   = bhead(step);
-          if (btail === null) {
-            bhead = null;
-          } else {
-            bhead = btail._1;
-            btail = btail._2;
+          try {
+            step   = bhead(step);
+            if (btail === null) {
+              bhead = null;
+            } else {
+              bhead = btail._1;
+              btail = btail._2;
+            }
+          } catch (e) {
+            status = RETURN;
+            fail   = util.left(e);
+            step   = null;
           }
           break;
 


### PR DESCRIPTION
This puts a try-catch around the bind step in order to try to catch code
that is not expected to have effects but does (by throwing).

While this is clearly a programming error, it is certainly not
implausible that effects creep into FFI code inadvertently for Aff
users. This allows us to be defensive in that case and recover, rather
than have all asynchronous options quitely not work after.

The addition of the try-catch does not seem to have a performance impact
(tested on Node v10.15.3). With and without this change, `pulp test`
takes ~4.8s to run.

There is a discussion around this on #172.