### PR TITLE
FIX: Supervisor leaks memory by not unregistering Fibers in COMPLETE

### DIFF
--- a/src/Effect/Aff.js
+++ b/src/Effect/Aff.js
@@ -160,7 +160,7 @@ var Aff = function () {
               delete fibers[fid];
             };
           }
-        });
+        })();
         fibers[fid] = fiber;
         count++;
       },


### PR DESCRIPTION
state.