### PR TITLE
Add roles declarations to allow safe coercions

### DIFF
--- a/src/Effect/Aff.purs
+++ b/src/Effect/Aff.purs
@@ -63,6 +63,8 @@ import Unsafe.Coerce (unsafeCoerce)
 -- | `makeAff` or `liftEffect`.
 foreign import data Aff ∷ Type → Type
 
+type role Aff representational
+
 instance functorAff ∷ Functor Aff where
   map = _map
 
@@ -116,6 +118,8 @@ instance lazyAff ∷ Lazy (Aff a) where
 -- | Applicative for running parallel effects. Any `Aff` can be coerced to a
 -- | `ParAff` and back using the `Parallel` class.
 foreign import data ParAff ∷ Type → Type
+
+type role ParAff representational
 
 instance functorParAff ∷ Functor ParAff where
   map = _parAffMap


### PR DESCRIPTION
This allows terms of type `Aff a` and `ParAff a` to be coerced to type `Aff b` and `ParAff b` when `Coercible a b` holds, hence allowing the zero cost `coerce` instead of `map wrap` and `map unwrap` to introduce and eliminate newtypes under asynchronous computations for instance.
